### PR TITLE
Downcase require rmagick to avoid deprecation warning

### DIFF
--- a/lib/sprockets/svg.rb
+++ b/lib/sprockets/svg.rb
@@ -1,7 +1,7 @@
 require 'sprockets/svg/version'
 
 require 'nokogiri'
-require 'RMagick'
+require 'rmagick'
 
 module Sprockets
   module Svg


### PR DESCRIPTION
We were seeing deprecation warnings for requiring `RMagick`. 

This downcases the require to remove the deprecation warning. 

@byroot 

/cc @mpiotrowicz @tessalt @haani @AWaselnuk
