### PR TITLE
Strip png timestamps to ensure PNG output is consistent over time

### DIFF
--- a/sprockets-svg.gemspec
+++ b/sprockets-svg.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sprockets', '>= 3'
   spec.add_dependency 'nokogiri'
   spec.add_dependency 'rmagick'
+  spec.add_dependency 'chunky_png'
 end


### PR DESCRIPTION
I red / greened it. The fingerprint was changing on every run before. It's now consistent.

It's likely still dependent on the imagemagick version though, so not sure if the local fingerprint will match Travis's. It might also break on random people computers if they try to run specs locally.

@rafaelfranca @wvanbergen for review please.
