### PR TITLE
Switch to interface compatible with Sprockets 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+sudo: false
+cache: bundler
+language: ruby
+before_script:
+  - gem install bundler
 rvm:
   - 2.0
-  - 2.1
+  - 2.1.6
+  - 2.2.5
+  - 2.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,10 @@ gem 'rspec'
 gem 'rspec-rails'
 gem 'sass-rails'
 gem 'rails'
-gem 'sprockets-rails', '>= 3.0.0.beta2'
+gem 'sprockets-rails'
 
-if RUBY_VERSION >= '2'
-  gem 'byebug'
+if RUBY_VERSION < '2.2'
+  gem 'rack', '~> 1.x'
 end
+
+gem 'byebug'

--- a/lib/sprockets/svg.rb
+++ b/lib/sprockets/svg.rb
@@ -24,10 +24,7 @@ module Sprockets
     end
 
     def install(assets)
-      assets.register_preprocessor 'image/svg+xml', :svg_min do |context, data|
-        Sprockets::Svg::Cleaner.process(data)
-      end
-
+      assets.register_preprocessor 'image/svg+xml', Sprockets::Svg::Cleaner
       assets.register_transformer 'image/svg+xml', 'image/png', -> (input) {
         Sprockets::Svg.convert(input[:data])
       }

--- a/lib/sprockets/svg/cleaner.rb
+++ b/lib/sprockets/svg/cleaner.rb
@@ -11,6 +11,10 @@ module Sprockets
         document.xpath('//comment()').remove
         document.to_s.gsub("\n", '').gsub(/>\s+</, '><').strip
       end
+
+      def self.call(input)
+        process(input[:data])
+      end
     end
   end
 end

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -72,7 +72,7 @@ describe 'Sprockets::Svg' do
       get :test, file: 'facebook.png'
       expect(response).to be_success
       expect(response.body.force_encoding('utf-8')).to be_starts_with("\x89PNG\r\n".force_encoding('utf-8'))
-      expect(response.headers['Content-Type']).to be == 'image/png'
+      expect(response.headers['Content-Type']).to match %r{image/png}
     end
 
     it 'compile scss' do


### PR DESCRIPTION
Hi @byroot 

Using `sprockets-svg` currently causes the following error in sprockets 3.7

```
DEPRECATION WARNING: You are using the a deprecated processor interface #<Proc:0x007ff405d0eef8@/Users/bouke/.gem/ruby/2.2.3/gems/sprockets-svg-1.1.0/lib/sprockets/svg.rb:27>.
Please update your processor interface:
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
 (called from install at /Users/bouke/.gem/ruby/2.2.3/gems/sprockets-svg-1.1.0/lib/sprockets/svg.rb:27)
```

This PR modifies the Gem to be compatible with Sprockets 3 and 4
