### PR TITLE
Faster PNG striping

### DIFF
--- a/lib/sprockets/svg.rb
+++ b/lib/sprockets/svg.rb
@@ -18,9 +18,16 @@ module Sprockets
     end
 
     def strip_png_metadata(png_blob)
-      image = ChunkyPNG::Image.from_blob(png_blob)
-      USELESS_PNG_METADATA.each(&image.metadata.method(:delete))
-      image.to_blob
+      image = ChunkyPNG::Datastream.from_blob(png_blob)
+
+      image.other_chunks.reject! do |chunk|
+        chunk.type == "tIME" ||
+          (chunk.respond_to?(:keyword) && USELESS_PNG_METADATA.include?(chunk.keyword))
+      end
+
+      str = StringIO.new
+      image.write(str)
+      str.string
     end
 
     def install(assets)


### PR DESCRIPTION
I found that when the image is really big the ChunkyPNG gem is slow to encode/decode the PNG pixels. As we only want to strip the metadata we can work in the Datastream that doesn't transform the pixels.

With my test image this method went from 10s to 0.01s.
